### PR TITLE
Restrict moderator access to forums

### DIFF
--- a/featherbb/Controller/Forum.php
+++ b/featherbb/Controller/Forum.php
@@ -83,6 +83,7 @@ class Forum
             'start_from' => $start_from,
             'url_forum' => $url_forum,
             'forum_actions' => $forum_actions,
+            'is_admmod' => $is_admmod,
         ))->addTemplate('forum.php')->display();
     }
 
@@ -279,3 +280,4 @@ class Forum
         }
     }
 }
+

--- a/featherbb/View/forum.php
+++ b/featherbb/View/forum.php
@@ -94,7 +94,7 @@ Container::get('hooks')->fire('view.forum.start');
             <p class="pagelink conl"><?= $paging_links ?></p>
 <?= $post_link ?>
 <?php
-if (isset($active_page) && ($active_page == 'Forum') && User::isAdminMod()) {
+if (isset($active_page) && ($active_page == 'Forum') && ($is_admmod === true)) {
     echo "\t\t\t".'<div id="modcontrols" class="inbox">'."\n";
     echo "\t\t\t\t".'<dl>'."\n";
     echo "\t\t\t\t\t".'<dt><strong>'.__('Mod controls').'</strong></dt>'."\n";
@@ -115,3 +115,4 @@ Container::get('hooks')->fire('view.forum.mod.actions');
 </div>
 <?php
 Container::get('hooks')->fire('view.forum.end');
+

--- a/featherbb/View/topic.php
+++ b/featherbb/View/topic.php
@@ -111,7 +111,7 @@ foreach ($post_data as $post) {
             <p class="pagelink conl"><?= $paging_links ?></p>
 <?= $post_link ?>
 <?php
-if (isset($active_page) && $active_page == 'Topic' && User::isAdminMod()) {
+if (isset($active_page) && ($active_page == 'Topic') && ($is_admmod === true)) {
     if (isset($pid)) {
         $parameter = $pid;
     } elseif (isset($page_number) && $page_number != 1) {
@@ -126,15 +126,15 @@ if (isset($active_page) && $active_page == 'Topic' && User::isAdminMod()) {
     echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('moveTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject']), 'fid' => $fid]).'">'.__('Move topic').'</a></span></dd>'."\n";
 
     if ($cur_topic['closed'] == '1') {
-        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('openTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject'])]).'">'.__('Open topic').'</a></span></dd>'."\n";
+        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('openTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject']), 'fid' => $fid]).'">'.__('Open topic').'</a></span></dd>'."\n";
     } else {
-        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('closeTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject'])]).'">'.__('Close topic').'</a></span></dd>'."\n";
+        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('closeTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject']), 'fid' => $fid]).'">'.__('Close topic').'</a></span></dd>'."\n";
     }
 
     if ($cur_topic['sticky'] == '1') {
-        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('unstickTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject'])]).'">'.__('Unstick topic').'</a></span></dd>'."\n";
+        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('unstickTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject']), 'fid' => $fid]).'">'.__('Unstick topic').'</a></span></dd>'."\n";
     } else {
-        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('stickTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject'])]).'">'.__('Stick topic').'</a></span></dd>'."\n";
+        echo "\t\t\t\t\t".'<dd><span><a href="'.Router::pathFor('stickTopic', ['id' => $tid, 'name' => Url::url_friendly($cur_topic['subject']), 'fid' => $fid]).'">'.__('Stick topic').'</a></span></dd>'."\n";
     }
 
     echo "\t\t\t\t".'</dl>'."\n";
@@ -229,3 +229,4 @@ if ($quickpost) {
 }
 
 Container::get('hooks')->fire('view.topic.end');
+

--- a/featherbb/routes.php
+++ b/featherbb/routes.php
@@ -39,10 +39,10 @@ Route::group('/topic', function() {
     Route::get('/{id:\d+}/{name:[\w\-]+}/action/{action:[\w\-]+}', '\FeatherBB\Controller\Topic:action')->setName('topicAction');
     Route::get('/{id:\d+}/{name:[\w\-]+}/subscribe', '\FeatherBB\Controller\Topic:subscribe')->add(new IsLogged)->setName('subscribeTopic');
     Route::get('/{id:\d+}/{name:[\w\-]+}/unsubscribe', '\FeatherBB\Controller\Topic:unsubscribe')->add(new IsLogged)->setName('unsubscribeTopic');
-    Route::get('/{id:\d+}/{name:[\w\-]+}/close', '\FeatherBB\Controller\Topic:close')->add(new IsAdmMod)->setName('closeTopic');
-    Route::get('/{id:\d+}/{name:[\w\-]+}/open', '\FeatherBB\Controller\Topic:open')->add(new IsAdmMod)->setName('openTopic');
-    Route::get('/{id:\d+}/{name:[\w\-]+}/stick', '\FeatherBB\Controller\Topic:stick')->add(new IsAdmMod)->setName('stickTopic');
-    Route::get('/{id:\d+}/{name:[\w\-]+}/unstick', '\FeatherBB\Controller\Topic:unstick')->add(new IsAdmMod)->setName('unstickTopic');
+    Route::get('/{id:\d+}/{name:[\w\-]+}/close/{fid:\d+}', '\FeatherBB\Controller\Topic:close')->add(new IsAdmMod)->setName('closeTopic');
+    Route::get('/{id:\d+}/{name:[\w\-]+}/open/{fid:\d+}', '\FeatherBB\Controller\Topic:open')->add(new IsAdmMod)->setName('openTopic');
+    Route::get('/{id:\d+}/{name:[\w\-]+}/stick/{fid:\d+}', '\FeatherBB\Controller\Topic:stick')->add(new IsAdmMod)->setName('stickTopic');
+    Route::get('/{id:\d+}/{name:[\w\-]+}/unstick/{fid:\d+}', '\FeatherBB\Controller\Topic:unstick')->add(new IsAdmMod)->setName('unstickTopic');
     Route::map(['GET', 'POST'], '/{id:\d+}/{name:[\w\-]+}/move/from/{fid:\d+}', '\FeatherBB\Controller\Topic:move')->add(new IsAdmMod)->setName('moveTopic');
     Route::map(['GET', 'POST'], '/{id:\d+}/{name:[\w\-]+}/moderate/forum/{fid:\d+}[/page/{page:\d+}]', '\FeatherBB\Controller\Topic:moderate')->add(new IsAdmMod)->setName('moderateTopic');
 })->add(new CanReadBoard);
@@ -231,3 +231,4 @@ Container::set('errorHandler', function ($c) {
         ))->addTemplate('error.php')->display();
     };
 });
+


### PR DESCRIPTION
I think it would make more sense to let moderators have access to mod functions only at the forum(s) they are assigned to. As it is now, some functions (move, open/close and stick/unstick) can be accessed globally (in topic view) by the moderators due to the use of `User::isAdminMod()`, which only checks if the user belongs to the moderator group. I suggest you include a more strict check in the topic and forum view to hide the mod controls to unassigned moderators, and also add checks in the Topic.php controller to block unauthorized (moderator) access to the moderator methods (move, open/close and stick/unstick).

Poffen
